### PR TITLE
Use netcoreapp1.0 for test projects.

### DIFF
--- a/RecipeMsTest/RecipeMsTest.csproj
+++ b/RecipeMsTest/RecipeMsTest.csproj
@@ -13,7 +13,7 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.1.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
       <Version>1.0.0-alpha-20161104-2</Version>

--- a/RecipeXunit/RecipeXunit.csproj
+++ b/RecipeXunit/RecipeXunit.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.1.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
       <Version>1.0.0-alpha-20161104-2</Version>


### PR DESCRIPTION
This is a workaround since VS 2017 RC doesn't support netcoreapp1.1 test projects (yet).